### PR TITLE
Adds in config loaders and other helper util files

### DIFF
--- a/ncdssdk/src/main/python/ncdsclient/internal/utils/AuthenticationConfigLoader.py
+++ b/ncdssdk/src/main/python/ncdsclient/internal/utils/AuthenticationConfigLoader.py
@@ -1,0 +1,53 @@
+import os
+from ncdssdk.src.main.python.ncdsclient.internal.utils.IsItPyTest import is_py_test
+from ncdssdk.src.main.python.ncdsclient.internal.utils.Oauth import Oauth
+import logging
+
+
+class AuthenticationConfigLoader:
+    """
+    Utility to load the auth configuration parameters.
+    """
+
+    def __init__(self):
+        self.OAUTH_TOKEN_ENDPOINT_URI = "oauth.token.endpoint.uri"
+        self.OAUTH_CLIENT_ID = "oauth.client.id"
+        self.OAUTH_CLIENT_SECRET = "oauth.client.secret"
+        self.OAUTH_USERNAME_CLAIM = "oauth.username.claim"
+        self.logger = logging.getLogger(__name__)
+
+    def get_client_id(self, cfg):
+        try:
+            if not cfg:
+                raise Exception("Missing config.")
+            if not is_py_test():
+                clientID = cfg[self.OAUTH_CLIENT_ID] if not os.getenv(
+                    "OAUTH_CLIENT_ID") else os.getenv("OAUTH_CLIENT_ID")
+            else:
+                clientID = "unit-test"
+            return clientID
+        except Exception as e:
+            logging.exception(e)
+            return
+
+    def add_nasdaq_specific_auth_properties(self, properties):
+        if not is_py_test():
+            properties["oauth.username.claim"] = "preferred_username"
+
+        return properties
+
+    def validate_security_config(self, cfg):
+        self.add_nasdaq_specific_auth_properties(cfg)
+        if self.OAUTH_TOKEN_ENDPOINT_URI not in cfg or cfg[self.OAUTH_TOKEN_ENDPOINT_URI] is None:
+            raise Exception("Authentication Setting :" +
+                            self.OAUTH_TOKEN_ENDPOINT_URI + " Missing")
+        if self.OAUTH_CLIENT_ID not in cfg or cfg[self.OAUTH_CLIENT_ID] is None and os.getenv("OAUTH_CLIENT_ID") is None:
+            raise Exception("Authentication Setting :" +
+                            self.OAUTH_CLIENT_ID + " Missing")
+        if self.OAUTH_CLIENT_SECRET not in cfg or cfg[self.OAUTH_CLIENT_SECRET] is None and os.getenv("OAUTH_CLIENT_SECRET") is None:
+            raise Exception("Authentication Setting :" +
+                            self.OAUTH_CLIENT_SECRET + " Missing")
+        if self.OAUTH_USERNAME_CLAIM not in cfg or cfg[self.OAUTH_USERNAME_CLAIM] is None and os.getenv("OAUTH_USERNAME_CLAIM") is None:
+            raise Exception("Authentication Setting :" +
+                            self.OAUTH_USERNAME_CLAIM + " Missing")
+        return True

--- a/ncdssdk/src/main/python/ncdsclient/internal/utils/IsItPyTest.py
+++ b/ncdssdk/src/main/python/ncdsclient/internal/utils/IsItPyTest.py
@@ -1,0 +1,7 @@
+import os
+
+
+def is_py_test():
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return True
+    return False

--- a/ncdssdk/src/main/python/ncdsclient/internal/utils/KafkaConfigLoader.py
+++ b/ncdssdk/src/main/python/ncdsclient/internal/utils/KafkaConfigLoader.py
@@ -1,0 +1,43 @@
+from ncdssdk.src.main.python.ncdsclient.internal.utils.IsItPyTest import is_py_test
+import ncdssdk.src.tests.resources as sysresources
+import json
+
+from importlib import resources
+import logging
+
+
+class KafkaConfigLoader:
+    """
+    Utility to load the kafka configuration parameters.
+    """
+
+    def __init__(self):
+        self.BOOTSTRAP_SERVERS = "bootstrap.servers"
+        self.logger = logging.getLogger(__name__)
+
+    @staticmethod
+    def load_test_config():
+        cfg = {}
+
+        with resources.open_text(sysresources, "pytest-config.json") as f:
+            cfg = json.load(f)
+        f.close()
+
+        return cfg
+
+    @staticmethod
+    def nasdaq_specific_config(p):
+        if not is_py_test():
+            p["security.protocol"] = "SASL_SSL"
+            p["sasl.mechanism"] = "OAUTHBEARER"
+            p["ssl.endpoint.identification.algorithm"] = "https"
+            p["enable.ssl.certificate.verification"] = False
+
+        return p
+
+    def validate_and_add_specific_properties(self, p):
+        if not p[self.BOOTSTRAP_SERVERS]:
+            raise Exception(
+                "bootstrap.servers Properties is not set in the Kafka Configuration")
+        self.nasdaq_specific_config(p)
+        return p

--- a/ncdssdk/src/main/python/ncdsclient/internal/utils/Oauth.py
+++ b/ncdssdk/src/main/python/ncdsclient/internal/utils/Oauth.py
@@ -1,0 +1,24 @@
+from requests_oauthlib import OAuth2Session
+from oauthlib.oauth2 import BackendApplicationClient
+import logging
+
+
+class Oauth:
+    """
+    Utility class for creating the oauth callback function passed into the consumer.
+    """
+
+    def __init__(self, auth_config):
+        self.token_url = auth_config["oauth.token.endpoint.uri"]
+        self.client_id = auth_config["oauth.client.id"]
+        self.client_secret = auth_config["oauth.client.secret"]
+        self.logger = logging.getLogger(__name__)
+
+    def oauth_cb(self, config_str):
+        client = BackendApplicationClient(client_id=self.client_id)
+        oauth = OAuth2Session(client=client)
+        token_json = oauth.fetch_token(
+            token_url=self.token_url, client_id=self.client_id, client_secret=self.client_secret)
+        token = token_json["access_token"]
+        expires_at = token_json["expires_at"]
+        return (token, expires_at)

--- a/ncdssdk/src/main/python/ncdsclient/internal/utils/SeekToMidnight.py
+++ b/ncdssdk/src/main/python/ncdsclient/internal/utils/SeekToMidnight.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+from confluent_kafka import OFFSET_BEGINNING, OFFSET_INVALID
+from datetime import datetime, date, timedelta, time
+
+logger = logging.getLogger(__name__)
+
+
+def seek_to_midnight_at_past_day(kafka_avro_consumer, topic_partition, num_days_ago=0):
+    topic_partition.offset = get_timestamp_at_midnight(num_days_ago)
+    logger.debug(
+        f"Num days ago: {num_days_ago}. Setting partition offset to timestamp: {topic_partition.offset}")
+    try:
+        logger.debug(f"topic partition: {topic_partition}")
+        offsets_for_times = kafka_avro_consumer.offsets_for_times(
+            [topic_partition], timeout=5)
+    except Exception as e:
+        logger.exception(e)
+        sys.exit(0)
+    logger.debug(f"{offsets_for_times[0]}: offsets for times")
+    partition_offset = offsets_for_times[0].offset
+    if offsets_for_times and partition_offset is not OFFSET_INVALID:
+        topic_partition.offset = partition_offset
+        logger.debug(f"Seeking to topic partition: {topic_partition}")
+        logger.debug(
+            f"making sure partition is assigned before seeking: {kafka_avro_consumer.ensure_assignment()}")
+        kafka_avro_consumer.seek(topic_partition)
+    else:
+        topic_partition.offset = OFFSET_BEGINNING
+        logger.debug(
+            f"No available offset. Continuing to seek from OFFSET_BEGINNING: {topic_partition}")
+        kafka_avro_consumer.seek(topic_partition)
+    return kafka_avro_consumer
+
+
+def get_timestamp_at_midnight(num_days_ago=0):
+    past_day = date.today()-timedelta(days=num_days_ago)
+    midnight = datetime.combine(past_day, time.min)
+    return int(midnight.timestamp() * 1000)


### PR DESCRIPTION
- Implements the authentication config and kafka config loaders 
- Adds in some helper util files: `IsItPyTest.py` for checking if a pytest is running, `Oauth.py` for returning the oauth callback, `SeekToMidnight.py` to help a consumer seek back to a certain timestamp