### PR TITLE
Fix deserialization issue with a bytes field 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Nasdaq Cloud Data Service (NCDS) provides a modern and efficient method of deliv
 
 
 
-### Items To Note
+# Items To Note
 
 * Connecting to the API requires credentials, which are provided by the Nasdaq Data Operations team during an on-boarding process
 * This sample code only connects to one topic (NLSCTA); during on-boarding process, you will receive a topic list that you're entitled to.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ For example:
 
   Replace example stream properties in the file **kafka-config.json** (https://github.com/Nasdaq/NasdaqCloudDataService-SDK-Python/blob/master/ncdssdk_client/src/main/python/resources/kafka-config.json) with provided values during on-boarding.
 
-  Required kafka configuration
+  **Note**: Ensure that the full path to the ca.crt file is provided. If the certificate was installed in the directory 
+  `/my/trusted/store/ncdsinstallcerts`, then the full path would be `/my/trusted/store/ncdsinstallcerts/ca.crt`
 
   **Note**: Ensure that the full path to the ca.crt file is provided. If the certificate was installed in the directory 
   `/my/trusted/store/ncdsinstallcerts`, then the full path would be `/my/trusted/store/ncdsinstallcerts/ca.crt`
@@ -304,7 +305,7 @@ while True:
         print(f"No Records Found for the Topic: {topic}")
               
     for message in messages:
-        print(f"value :" + message.value())
+        print(f"value :" + str(message.value()))
 ```
 
 Example output:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ For example:
 
   Required kafka configuration
 
+  **Note**: Ensure that the full path to the ca.crt file is provided. If the certificate was installed in the directory 
+  `/my/trusted/store/ncdsinstallcerts`, then the full path would be `/my/trusted/store/ncdsinstallcerts/ca.crt`
+
 ```properties
-"bootstrap.servers": {streams_endpoint_url}:9094
-"ssl.ca.location": ca.crt
+"bootstrap.servers": "{streams_endpoint_url}:9094"
+"ssl.ca.location": "/path/to/dir/ca.crt"
 ```
 
   For optional consumer configurations see: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
@@ -81,9 +84,9 @@ Replace example client authentication properties in the file **client-authentica
 
 
 ```properties
-oauth.token.endpoint.uri: https://{auth_endpoint_url}/auth/realms/demo/protocol/openid-connect/token
-oauth.client.id: client
-oauth.client.secret: client-secret
+oauth.token.endpoint.uri: "https://{auth_endpoint_url}/auth/realms/demo/protocol/openid-connect/token"
+oauth.client.id: "client_id"
+oauth.client.secret: "client_secret"
 ```
 
 ### Create NCDS Session Client

--- a/ncdssdk/src/main/python/ncdsclient/NCDSClient.py
+++ b/ncdssdk/src/main/python/ncdsclient/NCDSClient.py
@@ -134,7 +134,7 @@ class NCDSClient:
                         "--------------------------------END of Stream------------------")
                     break
                 for message in messages:
-                    msg_val = json.loads(message.value())
+                    msg_val = message.value()
                     if "schema_name" in msg_val and msg_val["schema_name"] == message_name:
                         sample_msg = str(msg_val)
                         if all_messages:

--- a/ncdssdk/src/main/python/ncdsclient/internal/AvroDeserializer.py
+++ b/ncdssdk/src/main/python/ncdsclient/internal/AvroDeserializer.py
@@ -26,6 +26,7 @@ class AvroDeserializer():
             event_dict = reader.read(decoder)
         except Exception as e:
             logging.exception(e)
+            raise e
 
         union_schema = True
         try:
@@ -48,7 +49,4 @@ class AvroDeserializer():
         else:
             event_dict["schema_name"] = reader.readers_schema.name
 
-        json_data = json.dumps(event_dict)
-
-        # Add new field 'schema_name' so that the user can filter a message by the schema name
-        return json_data
+        return event_dict

--- a/ncdssdk/src/main/python/ncdsclient/internal/ReadSchemaTopic.py
+++ b/ncdssdk/src/main/python/ncdsclient/internal/ReadSchemaTopic.py
@@ -49,7 +49,7 @@ class ReadSchemaTopic:
                 break
             for message in reversed(schema_messages):
                 try:
-                    msg_val = json.loads(message.value())
+                    msg_val = message.value()
 
                     latest_record = None
                     if "name" in msg_val and msg_val["name"] == topic:
@@ -64,7 +64,7 @@ class ReadSchemaTopic:
         message_schema = None
        # print("schema consumer", schema_consumer)
         if latest_record:
-            latest_record_val = json.loads(latest_record.value())
+            latest_record_val = latest_record.value()
             message_schema = avro.schema.parse(latest_record_val['schema'])
         schema_consumer.close()
 
@@ -94,7 +94,7 @@ class ReadSchemaTopic:
             if message is None:
                 break
 
-            msg_val = json.loads(message.value())
+            msg_val = message.value()
 
             name = msg_val['name']
             topics.add(name)

--- a/ncdssdk/src/tests/NCDSSDKPyTest.py
+++ b/ncdssdk/src/tests/NCDSSDKPyTest.py
@@ -39,7 +39,7 @@ def test_top_messages_with_timestamp():
     records = ncds_client.top_messages(topic, timestamp)
     for record in records:
         print(record.offset(), record.timestamp())
-        mock_records_from_kafka.append(json.loads(record.value()))
+        mock_records_from_kafka.append(record.value())
     assert len(mock_records_from_kafka) == 8
     assert mock_records[2:] == mock_records_from_kafka
 
@@ -53,7 +53,7 @@ def test_insertion():
     ncds_client = NCDSClient(None, None)
     records = ncds_client.top_messages(topic)
     for record in records:
-        mock_records_from_kafka.append(json.loads(record.value()))
+        mock_records_from_kafka.append(record.value())
     assert mock_records == mock_records_from_kafka
 
 

--- a/ncdssdk_client/src/main/python/ncdsclient/NCDSSession.py
+++ b/ncdssdk_client/src/main/python/ncdsclient/NCDSSession.py
@@ -172,7 +172,7 @@ class NCDSSession:
                         symbol = None
                         msg_name = None
                         try:
-                            msg_val = json.loads(message.value())
+                            msg_val = message.value()
                             symbol = msg_val['symbol']
                             msg_name = msg_val['schema_name']
                             self.logger.debug(

--- a/python_sdk_examples.ipynb
+++ b/python_sdk_examples.ipynb
@@ -2,6 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3492b987",
+   "metadata": {},
    "source": [
     "# Using the NCDS Python SDK\n",
     "\n",
@@ -10,42 +12,47 @@
     "Nasdaq Cloud Data Service (NCDS) provides a modern and efficient method of delivery for realtime exchange data and other financial information. Data is made available through a suite of APIs, allowing for effortless integration of data from disparate sources, and a dramatic reduction in time to market for customer-designed applications. The API is highly scalable, and robust enough to support the delivery of real-time exchange data.  \n",
     "\n",
     "**NOTE**: Be sure that your notebook is using Python 3.9 when running the examples"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "baf91a24",
+   "metadata": {},
    "source": [
     "## Installation\n",
     "\n",
     "Install the dependencies and certificate necessary for running the notebook by running the following cell block."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a6c505ee",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "! pip install .\n",
     "! python ncdssdk_client/src/main/python/ncdsclient/NCDSSession.py -opt INSTALLCERTS -path ."
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1695a62a",
+   "metadata": {},
    "source": [
     "## Items To Note\n",
     "\n",
     "* Connecting to the API requires credentials, which are provided by the Nasdaq Data Operations team during an on-boarding process\n",
     "* This sample code only connects to one topic; during on-boarding process, you will receive a topic list that you're entitled to.\n",
     "* See https://github.com/Nasdaq/NasdaqCloudDataService-SDK-Java for our officially support Java-based SDK.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "7ca38c3f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "security_cfg = {\n",
     "    \"oauth.token.endpoint.uri\": \"https://{auth_endpoint_url}/auth/realms/demo/protocol/openid-connect/token\",\n",
@@ -57,44 +64,39 @@
     "    \"ssl.ca.location\": \"ca.crt\",\n",
     "    \"auto.offset.reset\": \"earliest\"\n",
     "}"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "caad7abe",
+   "metadata": {},
    "source": [
     "\n",
     "## Code Examples\n",
     "\n",
     "### Getting list of data stream available\n",
     "List all available data stream for the user"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "75589d27",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from ncdssdk import NCDSClient"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
-    "topics = ncds_client.list_topics_for_client()\n",
-    "print(\"Data set topics:\")\n",
-    "for topic_entry in topics:\n",
-    "    print(topic_entry)"
-   ],
+   "id": "e1438284",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Entitled data set topics:\n",
       "TOTALVIEW\n",
@@ -114,60 +116,63 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
+    "topics = ncds_client.list_topics_for_client()\n",
+    "print(\"Data set topics:\")\n",
+    "for topic_entry in topics:\n",
+    "    print(topic_entry)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "03d2bdae",
+   "metadata": {},
    "source": [
     "### Getting schema for the stream\n",
     "\n",
     "This method returns the schema for the stream in Apache Avro format (https://avro.apache.org/docs/current/spec.html)"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
-    "topic = \"NLSCTA\"\n",
-    "schema = ncds_client.get_schema_for_topic(topic)\n",
-    "print(schema)"
-   ],
+   "id": "271c5e0a",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "latest record found\n",
       "[{\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqAdjClosingPrice\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"int\", \"name\": \"adjClosingPrice\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqAdjClosingPriceLong\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"long\", \"name\": \"adjClosingPrice\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqDirectoryMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"marketClass\"}, {\"type\": \"string\", \"name\": \"fsi\"}, {\"type\": [\"null\", \"int\"], \"name\": \"roundLotSize\"}, {\"type\": [\"null\", \"string\"], \"name\": \"roundLotOnly\"}, {\"type\": [\"null\", \"string\"], \"name\": \"issueClass\"}, {\"type\": [\"null\", \"string\"], \"name\": \"issueSubtype\"}, {\"type\": [\"null\", \"string\"], \"name\": \"authenticity\"}, {\"type\": [\"null\", \"string\"], \"name\": \"shortThreshold\"}, {\"type\": [\"null\", \"string\"], \"name\": \"ipo\"}, {\"type\": [\"null\", \"string\"], \"name\": \"luldTier\"}, {\"type\": [\"null\", \"string\"], \"name\": \"etf\"}, {\"type\": [\"null\", \"int\"], \"name\": \"etfFactor\"}, {\"type\": [\"null\", \"string\"], \"name\": \"inverseETF\"}, {\"type\": [\"null\", \"string\"], \"name\": \"compositeId\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqEndOfDayTradeSummary\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"int\", \"name\": \"consHigh\"}, {\"type\": \"int\", \"name\": \"consLow\"}, {\"type\": \"int\", \"name\": \"consClose\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}, {\"type\": \"int\", \"name\": \"consOpen\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqEndOfDayTradeSummaryETMF\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"int\", \"name\": \"consHigh\"}, {\"type\": \"int\", \"name\": \"consHighNAV\"}, {\"type\": \"int\", \"name\": \"consLow\"}, {\"type\": \"int\", \"name\": \"consLowNAV\"}, {\"type\": \"int\", \"name\": \"consClose\"}, {\"type\": \"int\", \"name\": \"consCloseNAV\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}, {\"type\": \"int\", \"name\": \"consOpen\"}, {\"type\": \"int\", \"name\": \"consOpenNAV\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqEndOfDayTradeSummaryLong\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"long\", \"name\": \"consHigh\"}, {\"type\": \"long\", \"name\": \"consLow\"}, {\"type\": \"long\", \"name\": \"consClose\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}, {\"type\": \"long\", \"name\": \"consOpen\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqIPOMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"refForNetChange\"}, {\"type\": \"int\", \"name\": \"refPrice\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqIpoQuoting\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"int\", \"name\": \"releaseTime\"}, {\"type\": \"string\", \"name\": \"releaseQualifier\"}, {\"type\": \"int\", \"name\": \"ipoPrice\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqMWCB\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"long\", \"name\": \"level1\"}, {\"type\": \"long\", \"name\": \"level2\"}, {\"type\": \"long\", \"name\": \"level3\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqMWCBStatus\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"level\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqMarketCenterActionMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"market\"}, {\"type\": \"string\", \"name\": \"action\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqShortSaleRestrictionIndicator\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"regSHOAction\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqSystemEventMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"event\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeCancel\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"origControlNumber\"}, {\"type\": \"int\", \"name\": \"origPrice\"}, {\"type\": \"int\", \"name\": \"origSize\"}, {\"type\": \"string\", \"name\": \"origSaleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeCancelETMFMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"origControlNumber\"}, {\"type\": \"int\", \"name\": \"origPrice\"}, {\"type\": \"int\", \"name\": \"origNavPrice\"}, {\"type\": \"int\", \"name\": \"origSize\"}, {\"type\": \"string\", \"name\": \"origSaleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeCancelLong\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"origControlNumber\"}, {\"type\": \"long\", \"name\": \"origPrice\"}, {\"type\": \"int\", \"name\": \"origSize\"}, {\"type\": \"string\", \"name\": \"origSaleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeCorrection\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"origControlNumber\"}, {\"type\": \"int\", \"name\": \"origPrice\"}, {\"type\": \"int\", \"name\": \"origSize\"}, {\"type\": \"string\", \"name\": \"origSaleCondition\"}, {\"type\": \"string\", \"name\": \"correctedControlNumber\"}, {\"type\": \"int\", \"name\": \"correctedPrice\"}, {\"type\": \"int\", \"name\": \"correctedSize\"}, {\"type\": \"string\", \"name\": \"correctedSaleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeCorrectionETMFMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"origControlNumber\"}, {\"type\": \"int\", \"name\": \"origPrice\"}, {\"type\": \"int\", \"name\": \"origNavPremium\"}, {\"type\": \"int\", \"name\": \"origSize\"}, {\"type\": \"string\", \"name\": \"origSaleCondition\"}, {\"type\": \"string\", \"name\": \"correctedControlNumber\"}, {\"type\": \"int\", \"name\": \"correctedPrice\"}, {\"type\": \"int\", \"name\": \"correctedNavPremium\"}, {\"type\": \"int\", \"name\": \"correctedSize\"}, {\"type\": \"string\", \"name\": \"correctedSaleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeCorrectionLong\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"origControlNumber\"}, {\"type\": \"long\", \"name\": \"origPrice\"}, {\"type\": \"int\", \"name\": \"origSize\"}, {\"type\": \"string\", \"name\": \"origSaleCondition\"}, {\"type\": \"string\", \"name\": \"correctedControlNumber\"}, {\"type\": \"long\", \"name\": \"correctedPrice\"}, {\"type\": \"int\", \"name\": \"correctedSize\"}, {\"type\": \"string\", \"name\": \"correctedSaleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeReportETMFMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"controlNumber\"}, {\"type\": \"int\", \"name\": \"price\"}, {\"type\": \"int\", \"name\": \"size\"}, {\"type\": \"int\", \"name\": \"navPremium\"}, {\"type\": \"string\", \"name\": \"saleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeReportLongMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"controlNumber\"}, {\"type\": \"long\", \"name\": \"price\"}, {\"type\": \"int\", \"name\": \"size\"}, {\"type\": \"string\", \"name\": \"saleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradeReportMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"marketCenter\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"securityClass\"}, {\"type\": \"string\", \"name\": \"controlNumber\"}, {\"type\": \"int\", \"name\": \"price\"}, {\"type\": \"int\", \"name\": \"size\"}, {\"type\": \"string\", \"name\": \"saleCondition\"}, {\"type\": \"long\", \"name\": \"cosolidatedVolume\"}]}, {\"type\": \"record\", \"version\": \"1\", \"name\": \"SeqTradingStateMessage\", \"namespace\": \"com.nasdaq.equities.trades.applications.nls.messaging.binary21\", \"fields\": [{\"type\": \"int\", \"name\": \"SoupPartition\"}, {\"type\": \"long\", \"name\": \"SoupSequence\"}, {\"type\": \"long\", \"name\": \"trackingID\"}, {\"type\": \"string\", \"name\": \"msgType\"}, {\"type\": \"string\", \"name\": \"filler\"}, {\"type\": \"string\", \"name\": \"symbol\"}, {\"type\": \"string\", \"name\": \"market\"}, {\"type\": \"string\", \"name\": \"tradingState\"}, {\"type\": \"string\", \"name\": \"reason\"}]}]\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
+    "topic = \"NLSCTA\"\n",
+    "schema = ncds_client.get_schema_for_topic(topic)\n",
+    "print(schema)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1edb0601",
+   "metadata": {},
    "source": [
     "### Get first 10 messages of the stream"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "source": [
-    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
-    "topic = \"NLSCTA\"\n",
-    "records = ncds_client.top_messages(topic)\n",
-    "for i in range(0, 10):\n",
-    "    print(\"key: \", records[i].key())\n",
-    "    print(\"value: \", str(records[i].value()))"
-   ],
+   "id": "09efdd2e",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "latest record found\n",
       "key:  1\n",
@@ -193,19 +198,58 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
+    "topic = \"NLSCTA\"\n",
+    "records = ncds_client.top_messages(topic)\n",
+    "for i in range(0, 10):\n",
+    "    print(\"key: \", records[i].key())\n",
+    "    print(\"value: \", str(records[i].value()))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "89c3d200",
+   "metadata": {},
    "source": [
     "### Get first 10 messages of the stream from given timestamp\n",
     "This returns the first 10 available messages of the stream given timestamp in milliseconds since the UNIX epoch."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "f43d8fd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "latest record found\n",
+      "key:  1\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 1, \"trackingID\": 7233292771056, \"msgType\": \"S\", \"event\": \"O\", \"schema_name\": \"SeqSystemEventMessage\"}\n",
+      "key:  2\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 2, \"trackingID\": 11578719526113, \"msgType\": \"R\", \"symbol\": \"A\", \"marketClass\": \"N\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"C\", \"issueSubtype\": \"Z\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"1\", \"etf\": \"N\", \"etfFactor\": 0, \"inverseETF\": \"N\", \"compositeId\": \"BBG000C2V3D6\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
+      "key:  3\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 3, \"trackingID\": 11578719526113, \"msgType\": \"G\", \"symbol\": \"A\", \"securityClass\": \"N\", \"adjClosingPrice\": 1500300, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
+      "key:  4\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 4, \"trackingID\": 11578719831656, \"msgType\": \"R\", \"symbol\": \"AA\", \"marketClass\": \"N\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"C\", \"issueSubtype\": \"Z\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"1\", \"etf\": \"N\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00B3T3HD3\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
+      "key:  5\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 5, \"trackingID\": 11578719831656, \"msgType\": \"G\", \"symbol\": \"AA\", \"securityClass\": \"N\", \"adjClosingPrice\": 374400, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
+      "key:  6\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 6, \"trackingID\": 11578719879872, \"msgType\": \"R\", \"symbol\": \"AAA\", \"marketClass\": \"P\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"Q\", \"issueSubtype\": \"I\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"2\", \"etf\": \"Y\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00X5FSP48\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
+      "key:  7\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 7, \"trackingID\": 11578719879872, \"msgType\": \"G\", \"symbol\": \"AAA\", \"securityClass\": \"P\", \"adjClosingPrice\": 250050, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
+      "key:  8\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 8, \"trackingID\": 11578719916519, \"msgType\": \"R\", \"symbol\": \"AAAU\", \"marketClass\": \"P\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"Q\", \"issueSubtype\": \"I\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"1\", \"etf\": \"Y\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00LPXX872\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
+      "key:  9\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 9, \"trackingID\": 11578719916519, \"msgType\": \"G\", \"symbol\": \"AAAU\", \"securityClass\": \"P\", \"adjClosingPrice\": 179850, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
+      "key:  10\n",
+      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 10, \"trackingID\": 11578719950254, \"msgType\": \"R\", \"symbol\": \"AAC\", \"marketClass\": \"N\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"O\", \"issueSubtype\": \"Z\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"2\", \"etf\": \"N\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00YZC2Z91\", \"schema_name\": \"SeqDirectoryMessage\"}\n"
+     ]
+    }
+   ],
    "source": [
     "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
     "topic=\"NLSCTA\"\n",
@@ -214,92 +258,55 @@
     "for i in range(0, 10):\n",
     "    print(\"key: \", records[i].key())\n",
     "    print(\"value: \", str(records[i].value()))"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "latest record found\n",
-      "key:  1\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 1, \"trackingID\": 7233292771056, \"msgType\": \"S\", \"event\": \"O\", \"schema_name\": \"SeqSystemEventMessage\"}\n",
-      "key:  2\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 2, \"trackingID\": 11578719526113, \"msgType\": \"R\", \"symbol\": \"A\", \"marketClass\": \"N\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"C\", \"issueSubtype\": \"Z\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"1\", \"etf\": \"N\", \"etfFactor\": 0, \"inverseETF\": \"N\", \"compositeId\": \"BBG000C2V3D6\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
-      "key:  3\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 3, \"trackingID\": 11578719526113, \"msgType\": \"G\", \"symbol\": \"A\", \"securityClass\": \"N\", \"adjClosingPrice\": 1500300, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
-      "key:  4\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 4, \"trackingID\": 11578719831656, \"msgType\": \"R\", \"symbol\": \"AA\", \"marketClass\": \"N\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"C\", \"issueSubtype\": \"Z\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"1\", \"etf\": \"N\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00B3T3HD3\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
-      "key:  5\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 5, \"trackingID\": 11578719831656, \"msgType\": \"G\", \"symbol\": \"AA\", \"securityClass\": \"N\", \"adjClosingPrice\": 374400, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
-      "key:  6\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 6, \"trackingID\": 11578719879872, \"msgType\": \"R\", \"symbol\": \"AAA\", \"marketClass\": \"P\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"Q\", \"issueSubtype\": \"I\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"2\", \"etf\": \"Y\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00X5FSP48\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
-      "key:  7\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 7, \"trackingID\": 11578719879872, \"msgType\": \"G\", \"symbol\": \"AAA\", \"securityClass\": \"P\", \"adjClosingPrice\": 250050, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
-      "key:  8\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 8, \"trackingID\": 11578719916519, \"msgType\": \"R\", \"symbol\": \"AAAU\", \"marketClass\": \"P\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"Q\", \"issueSubtype\": \"I\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"1\", \"etf\": \"Y\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00LPXX872\", \"schema_name\": \"SeqDirectoryMessage\"}\n",
-      "key:  9\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 9, \"trackingID\": 11578719916519, \"msgType\": \"G\", \"symbol\": \"AAAU\", \"securityClass\": \"P\", \"adjClosingPrice\": 179850, \"schema_name\": \"SeqAdjClosingPrice\"}\n",
-      "key:  10\n",
-      "value:  {\"SoupPartition\": 0, \"SoupSequence\": 10, \"trackingID\": 11578719950254, \"msgType\": \"R\", \"symbol\": \"AAC\", \"marketClass\": \"N\", \"fsi\": \"\", \"roundLotSize\": 100, \"roundLotOnly\": \"N\", \"issueClass\": \"O\", \"issueSubtype\": \"Z\", \"authenticity\": \"P\", \"shortThreshold\": \"N\", \"ipo\": \"\", \"luldTier\": \"2\", \"etf\": \"N\", \"etfFactor\": 1, \"inverseETF\": \"N\", \"compositeId\": \"BBG00YZC2Z91\", \"schema_name\": \"SeqDirectoryMessage\"}\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ed5625ee",
+   "metadata": {},
    "source": [
     "### Get example message from stream\n",
     "Print message to the console for given message name."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "source": [
-    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
-    "topic = \"NLSCTA\"\n",
-    "print(ncds_client.get_sample_messages(topic, \"SeqDirectoryMessage\", all_messages=False))"
-   ],
+   "id": "1554eb95",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "latest record found\n",
       "{'SoupPartition': 0, 'SoupSequence': 500, 'trackingID': 11578737109589, 'msgType': 'R', 'symbol': 'AMN', 'marketClass': 'N', 'fsi': '', 'roundLotSize': 100, 'roundLotOnly': 'N', 'issueClass': 'C', 'issueSubtype': 'Z', 'authenticity': 'P', 'shortThreshold': 'N', 'ipo': '', 'luldTier': '2', 'etf': 'N', 'etfFactor': 0, 'inverseETF': 'N', 'compositeId': 'BBG000BCT197', 'schema_name': 'SeqDirectoryMessage'}\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
+    "topic = \"NLSCTA\"\n",
+    "print(ncds_client.get_sample_messages(topic, \"SeqDirectoryMessage\", all_messages=False))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0e600e73",
+   "metadata": {},
    "source": [
     "### Get continuous stream"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "source": [
-    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
-    "topic = \"NLSCTA\"\n",
-    "consumer = ncds_client.ncds_kafka_consumer(topic)\n",
-    "for i in range(0, 10):\n",
-    "    messages = consumer.consume(num_messages=1, timeout=5)\n",
-    "    if len(messages) == 0:\n",
-    "        print(f\"No Records Found for the Topic: {topic}\")\n",
-    "              \n",
-    "    for message in messages:\n",
-    "        print(f\"value :\" + message.value())"
-   ],
+   "id": "04d70f89",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "latest record found\n",
       "value :{\"SoupPartition\": 0, \"SoupSequence\": 1, \"trackingID\": 7233292771056, \"msgType\": \"S\", \"event\": \"O\", \"schema_name\": \"SeqSystemEventMessage\"}\n",
@@ -315,7 +322,18 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "ncds_client = NCDSClient(security_cfg, kafka_cfg)\n",
+    "topic = \"NLSCTA\"\n",
+    "consumer = ncds_client.ncds_kafka_consumer(topic)\n",
+    "for i in range(0, 10):\n",
+    "    messages = consumer.consume(num_messages=1, timeout=5)\n",
+    "    if len(messages) == 0:\n",
+    "        print(f\"No Records Found for the Topic: {topic}\")\n",
+    "              \n",
+    "    for message in messages:\n",
+    "        print(f\"value :\" + str(message.value()))"
+   ]
   }
  ],
  "metadata": {
@@ -334,7 +352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Remove the serialization of the avro message into a json string. This is unneeded as the deserialize function is allowed to return any object, and it causes issues when there is an avro field of type `bytes`, as this is not a valid type for json objects. 