### PR TITLE
Returns a dict not a string Get continuous stream

### DIFF
--- a/python_sdk_examples.ipynb
+++ b/python_sdk_examples.ipynb
@@ -261,7 +261,8 @@
     "        print(f\"No Records Found for the Topic: {topic}\")\n",
     "              \n",
     "    for message in messages:\n",
-    "        print(f\"value :\" + message.value())"
+    "        print(f\"value :\")"
+    "        print(message.value())"
    ],
    "outputs": [
     {


### PR DESCRIPTION
The last example returns a dict in the `message.value()` function not a string. This will give you an error if you run it.