### PR TITLE
Fix invalid notebook

### DIFF
--- a/python_sdk_examples.ipynb
+++ b/python_sdk_examples.ipynb
@@ -261,7 +261,7 @@
     "        print(f\"No Records Found for the Topic: {topic}\")\n",
     "              \n",
     "    for message in messages:\n",
-    "        print(f\"value :\")"
+    "        print(f\"value :\")",
     "        print(message.value())"
    ],
    "outputs": [


### PR DESCRIPTION
I received the following error when trying to run the notebook:
```
Unreadable Notebook: NasdaqCloudDataService-SDK-Python/python_sdk_examples.ipynb NotJSONError('Notebook does not appear to be JSON: \'{\\n "cells": [\\n {\\n "cell_type": "m...')
```
After adding the missing comma, I was able to run the notebook with no issue