### PR TITLE
Convert Eager Logging to Lazy Logging

### DIFF
--- a/ncdssdk/src/main/python/ncdsclient/consumer/NasdaqKafkaAvroConsumer.py
+++ b/ncdssdk/src/main/python/ncdsclient/consumer/NasdaqKafkaAvroConsumer.py
@@ -99,20 +99,20 @@ class NasdaqKafkaAvroConsumer():
                 return kafka_consumer
 
         else:
-            self.logger.debug("Timestamp is not none: " + str(timestamp))
+            self.logger.debug("Timestamp is not none: %s", str(timestamp))
             try:
                 topic_partition.offset = timestamp
                 self.logger.debug(
-                    "offset: " + str(topic_partition.offset) + ", timestamp: " + str(timestamp))
+                    "offset: %s, timestamp: %s", str(topic_partition.offset), str(timestamp))
                 offsets_for_times = kafka_consumer.offsets_for_times(
                     [topic_partition], self.kafka_props.get(self.kafka_config_loader.TIMEOUT))
             except Exception as e:
                 self.logger.exception(e)
                 sys.exit(0)
             self.logger.debug(
-                "topic partition before offsets_for_times: " + str(topic_partition))
+                "topic partition before offsets_for_times: %s", str(topic_partition))
             self.logger.debug(
-                "topic partition after offsets for times: " + str(offsets_for_times))
+                "topic partition after offsets for times: %s", str(offsets_for_times))
             partition_offset = offsets_for_times[0].offset
             self.logger.debug(
                 f"Successfully received offset {partition_offset}")


### PR DESCRIPTION
This codemod converts "eager" logging into "lazy" logging, which is preferred for performance efficiency and resource optimization.
Lazy logging defers the actual construction and formatting of log messages until it's confirmed that the message will be logged based on the current log level, thereby avoiding unnecessary computation for messages that will not be logged. 

Our changes look something like this:

```diff
import logging
e = "Some error"
- logging.error("Error occurred: %s" % e)
- logging.error("Error occurred: " + e)
+ logging.error("Error occurred: %s", e)
+ logging.error("Error occurred: %s", e)
```


Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/lazy-logging](https://docs.pixee.ai/codemods/python/pixee_python_lazy-logging)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2FNasdaqCloudDataService-SDK-Python%7C6ee19c440b46cb7f798ecf902666a6effeb6eed5)

<!--{"type":"DRIP","codemod":"pixee:python/lazy-logging"}-->