### PR TITLE
python_sdk_examples.ipynb corrupted json - missing comma

### DIFF
--- a/python_sdk_examples.ipynb
+++ b/python_sdk_examples.ipynb
@@ -261,7 +261,7 @@
     "        print(f\"No Records Found for the Topic: {topic}\")\n",
     "              \n",
     "    for message in messages:\n",
-    "        print(f\"value :\")"
+    "        print(f\"value :\")",
     "        print(message.value())"
    ],
    "outputs": [


### PR DESCRIPTION
This change fixes the broken json file which otherwise can't be opened