### PR TITLE
Adding avro version below 1.12.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,5 +3,5 @@ confluent-kafka>=1.7.0,<2
 oauthlib>=3.1.0,<4
 requests>=2.25.1,<3
 requests-oauthlib>=1.3.0,<2
-avro>=1.10.2,<2
+avro>=1.10.2,<=1.12.0
 pytz>=2023.3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='ncdssdk',
-    version='0.5.0',
+    version='0.5.1',
     description='A Python SDK for developing applications to access the NCDS API',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -28,7 +28,7 @@ setup(
     ],
     keywords='Nasdaq, NCDS, ncdssdk',
     packages=find_packages(),
-    python_requires='>=3.9, <4',
+    python_requires='>=3.9, <3.11',
     install_requires=open("requirements.in").readlines(),
 
     include_package_data=True,


### PR DESCRIPTION
With recent upgrade on avro 1.12.1, kafka consumer has been failing. So pinning it to 1.12.0